### PR TITLE
feat: add sitemap

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,6 +5,10 @@ module.exports = function(config) {
   config.addFilter("timestamp", require("./filters/timestamp.js") );
   config.addFilter("squash", require("./filters/squash.js") );
 
+  config.addCollection('sitemap', collection => {
+  return collection.getFilteredByGlob('**/*.md');
+  });
+
   return {
     dir: {
       input: "src/site",

--- a/src/site/sitemap.njk
+++ b/src/site/sitemap.njk
@@ -1,0 +1,12 @@
+---
+permalink: /sitemap.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+{%- for item in collections.sitemap %}
+{%- if item.data.permalink != false %}
+  <url>
+    <loc>{{ site.url}}{{ item.url }}</loc>
+  </url>{% endif -%}
+{%- endfor %}
+</urlset>


### PR DESCRIPTION
fix #5 

This generates a very basic sitemap, that can be enhanced later: 

https://deploy-preview-6--mariealine-design.netlify.com/sitemap.xml

Eleventy currently has no plugin for sitemap, so I had to do it manually:

1. Add a global colllection `sitemap` that includes all markdown files
2. Create a nunjucks template to list all items in the `sitemap` collection that don't have a permalink set to `false`.